### PR TITLE
Fix CORS error by migrating to unpkg.com

### DIFF
--- a/src/components/withTurf.js
+++ b/src/components/withTurf.js
@@ -12,8 +12,8 @@ export default function withTurf (WrappedComponent) {
         useEffect(() => {
             async function fetchData () {
                 const [turf, npmData] = await Promise.all([
-                    // import Turf and package info
-                    fetch('https://npmcdn.com/@turf/turf', {redirect: 'follow'}).then(r => r.text()),
+                    // import Turf and package info, use 'turf.min.js' to explicitly require the iife version
+                    fetch('https://unpkg.com/@turf/turf/turf.min.js', {redirect: 'follow'}).then(r => r.text()),
                     getAbbreviatedPackument({name: '@turf/turf'}),
                 ]);
 


### PR DESCRIPTION
Closes #40 

Requests to _npmcdn.com_ fail with a CORS error. This PR migrates to _unpkg.com_ (which _npmcdn.com_ redirects to anyway).

With _unpkg.com_ we have to explicitly reference the `/turf.min.js` (iife) as it redirects to the cjs version by default, which leads to other errors.